### PR TITLE
Fix/niri unnamed workspaces

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -25,7 +25,6 @@ buildPythonApplication rec {
 
   dependencies = [
     geopy
-    i3ipc
     meson
     meson-python
     ninja

--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,6 @@
           makeWrapper
           (python3.withPackages (python-pkgs: with python-pkgs; [
             geopy
-            i3ipc
             meson
             meson-python
             ninja

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 ]
 dependencies = [
   "geopy",
-  "i3ipc",
   "meson-python",
   "meson",
   "ninja",

--- a/src/ngb/modules/__init__.py
+++ b/src/ngb/modules/__init__.py
@@ -3,5 +3,6 @@ from .config import Config
 from .dropdownwindow import DropDownWindow
 from .hyprlandipc import HyprlandIpc
 from .niriipc import NiriIPC
+from .swayipc import SwayIPC
 from .widgetbox import WidgetBox
 from .windowmanageripc import WindowManagerIPC

--- a/src/ngb/modules/hyprlandipc.py
+++ b/src/ngb/modules/hyprlandipc.py
@@ -41,14 +41,14 @@ class HyprlandIpc(WindowManagerIPC):
         return parsed_ws
 
     def get_workspaces(self):
-        workspace = namedtuple("workspace", ["name", "focused", "output", "urgent"])
+        workspace = namedtuple("workspace", ["id", "name", "focused", "output", "urgent"])
         workspaces = self.send_to_socket("workspaces")
         active_workspace = self.send_to_socket("activeworkspace")
         active_id = self.parse_workspace(active_workspace)[0]["id"]
         parsed_ws = self.parse_workspace(workspaces)
         ws_list = list()
         for p in parsed_ws:
-            ws_list.append(workspace(name=p["name"], focused=p["id"] == active_id, output=p["monitor"], urgent=False))
+            ws_list.append(workspace(id=p["id"], name=p["name"], focused=p["id"] == active_id, output=p["monitor"], urgent=False))
         return ws_list
 
     def translate_cmd(self, cmd):

--- a/src/ngb/modules/niriipc.py
+++ b/src/ngb/modules/niriipc.py
@@ -48,7 +48,7 @@ class NiriIPC(WindowManagerIPC):
             ws_dict = dict()
             if(wss != {} and wss["name"] != None and wss["active_window_id"] != None or (wss["is_active"] and wss["active_window_id"] == None)):
                 pass
-                ws_dict["id"] = wss["id"]
+                ws_dict["id"] = wss["idx"]
                 ws_dict["name"] = wss["name"]
                 ws_dict["monitor"] = wss["output"]
                 ws_dict["active"] = wss["is_active"]
@@ -65,13 +65,13 @@ class NiriIPC(WindowManagerIPC):
         return parsed_ws
 
     def get_workspaces(self):
-        workspace = namedtuple("workspace", ["name", "focused", "output", "urgent"])
+        workspace = namedtuple("workspace", ["id", "name", "focused", "output", "urgent"])
         workspaces = self.send_to_socket("Workspaces")
         if(workspaces and "Ok" in workspaces):
             parsed_ws = self.parse_workspace(workspaces["Ok"]["Workspaces"])
             ws_list = list()
             for p in parsed_ws:
-                ws_list.append(workspace(name=p["name"], focused=p["focused"], output=p["monitor"], urgent=p["urgent"]))
+                ws_list.append(workspace(id=p["id"], name=p["name"], focused=p["focused"], output=p["monitor"], urgent=p["urgent"]))
             return ws_list
         return []
 

--- a/src/ngb/modules/niriipc.py
+++ b/src/ngb/modules/niriipc.py
@@ -46,10 +46,9 @@ class NiriIPC(WindowManagerIPC):
         self.get_outputs()
         for wss in ws:
             ws_dict = dict()
-            if(wss != {} and wss["name"] != None and wss["active_window_id"] != None or (wss["is_active"] and wss["active_window_id"] == None)):
-                pass
+            if(wss != {} and wss["active_window_id"] != None or (wss["is_active"] and wss["active_window_id"] == None)):
                 ws_dict["id"] = wss["idx"]
-                ws_dict["name"] = wss["name"]
+                ws_dict["name"] = wss["name"] if wss["name"] else str(wss["id"])
                 ws_dict["monitor"] = wss["output"]
                 ws_dict["active"] = wss["is_active"]
                 ws_dict["urgent"] = wss["is_urgent"]

--- a/src/ngb/modules/swayipc.py
+++ b/src/ngb/modules/swayipc.py
@@ -2,20 +2,86 @@ from collections import namedtuple
 import socket
 import re
 import os
-import i3ipc
+import struct
+import json
 
 from .windowmanageripc import WindowManagerIPC
 
-class SwayIPC():
-    conn = i3ipc.Connection()
+class SwayIPC(WindowManagerIPC):
+    sock_req = f"{os.environ['SWAYSOCK']}"
+
+    def send_to_socket(self, cmd):
+        usocket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            usocket.connect(self.sock_req)
+            try:
+                usocket.sendall(self.translate_cmd(cmd))
+                usocket.sendall("\n".encode("utf-8"))
+                response = ""
+                while True:
+                    part = usocket.recv(1024)
+                    response += part.decode("utf-8")
+                    if(len(part) < 1024):
+                        break
+                match = re.search(r"\[[\W\w]*\]", response).group(0)
+                if(match):
+                    parsed_response = json.loads(match)
+                else:
+                    parsed_response = []
+                return parsed_response
+            except socket.error as e:
+                print(e)
+        except ConnectionRefusedError:
+            print("Connection to the UNIX socket refused.")
+        except socket.error as e:
+            print(f"Error open socket: {e}")
+        finally:
+            usocket.close()
 
     def get_workspaces(self):
         workspace = namedtuple("workspace", ["id", "name", "focused", "output", "urgent"])
-        wss = self.conn.get_workspaces()
+        wss = self.send_to_socket("GET_WORKSPACES")
         ws_list = list()
         for p in wss:
-            ws_list.append(workspace(id=p.num, name=p.name, focused=p.focused, output=p.output, urgent=p.urgent))
+            ws_list.append(workspace(id=p["num"], name=p["name"], focused=p["focused"], output=p["output"], urgent=p["urgent"]))
         return ws_list
 
-    def command(self, cmd):
-        self.conn.command(cmd)
+    def translate_cmd(self, cmd):
+        match cmd:
+            case "GET_WORKSPACES":
+                cmd_id = 1
+            case "SUBSCRIBE":
+                cmd_id = 2
+            case "GET_OUTPUTS":
+                cmd_id = 3
+            case "GET_TREE":
+                cmd_id = 4
+            case "GET_MARKS":
+                cmd_id = 5
+            case "GET_BAR_CONFIG":
+                cmd_id = 6
+            case "GET_VERSION":
+                cmd_id = 7
+            case "GET_BINDING_MODES":
+                cmd_id = 8
+            case "GET_CONFIG":
+                cmd_id = 9
+            case "SEND_TICK":
+                cmd_id = 10
+            case "SYNC":
+                cmd_id = 11
+            case "GET_BINDING_STATE":
+                cmd_id = 12
+            case "GET_INPUTS":
+                cmd_id = 100
+            case "GET_SEATS":
+                cmd_id = 101
+            case _:
+                cmd_id = 0
+
+        magic_string = "i3-ipc".encode("utf-8")
+        cmd_len = struct.pack("@i", len(cmd))
+        cmd_type = struct.pack("@i", cmd_id)
+
+        cmd_str = magic_string + cmd_len + cmd_type + cmd.encode("utf8")
+        return cmd_str

--- a/src/ngb/modules/swayipc.py
+++ b/src/ngb/modules/swayipc.py
@@ -8,7 +8,9 @@ import json
 from .windowmanageripc import WindowManagerIPC
 
 class SwayIPC(WindowManagerIPC):
-    sock_req = f"{os.environ['SWAYSOCK']}"
+
+    def __init__(self):
+        self.sock_req = f"{os.environ['SWAYSOCK']}"
 
     def send_to_socket(self, cmd):
         usocket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)

--- a/src/ngb/modules/swayipc.py
+++ b/src/ngb/modules/swayipc.py
@@ -1,0 +1,21 @@
+from collections import namedtuple
+import socket
+import re
+import os
+import i3ipc
+
+from .windowmanageripc import WindowManagerIPC
+
+class SwayIPC():
+    conn = i3ipc.Connection()
+
+    def get_workspaces(self):
+        workspace = namedtuple("workspace", ["id", "name", "focused", "output", "urgent"])
+        wss = self.conn.get_workspaces()
+        ws_list = list()
+        for p in wss:
+            ws_list.append(workspace(id=p.num, name=p.name, focused=p.focused, output=p.output, urgent=p.urgent))
+        return ws_list
+
+    def command(self, cmd):
+        self.conn.command(cmd)

--- a/src/ngb/widgets/workspaces.py
+++ b/src/ngb/widgets/workspaces.py
@@ -3,15 +3,14 @@ from gi.repository import GLib
 
 import re
 import os
-import i3ipc
 from collections import namedtuple
 import socket
 
-from ngb.modules import HyprlandIpc, NiriIPC, WidgetBox, WindowManagerIPC
+from ngb.modules import HyprlandIpc, NiriIPC, SwayIPC, WidgetBox, WindowManagerIPC
 
 class WorkspaceBox(WidgetBox):
     if(os.environ["XDG_CURRENT_DESKTOP"] == "sway"):
-        wm = i3ipc.Connection()
+        wm = SwayIPC()
     elif(os.environ["XDG_CURRENT_DESKTOP"] == "Hyprland"):
         wm = HyprlandIpc()
     elif(os.environ["XDG_CURRENT_DESKTOP"] == "niri"):
@@ -50,7 +49,7 @@ class Workspaces(Gtk.Box):
     workspaces = []
     old_workspaces = []
     if(os.environ["XDG_CURRENT_DESKTOP"] == "sway"):
-        wm = i3ipc.Connection()
+        wm = SwayIPC()
     elif(os.environ["XDG_CURRENT_DESKTOP"] == "Hyprland"):
         wm = HyprlandIpc()
     elif(os.environ["XDG_CURRENT_DESKTOP"] == "niri"):

--- a/src/ngb/widgets/workspaces.py
+++ b/src/ngb/widgets/workspaces.py
@@ -71,25 +71,19 @@ class Workspaces(Gtk.Box):
         self.scroll_controller.connect("scroll", self.on_scroll)
         self.add_controller(self.scroll_controller)
 
-    def sort_key(self, item):
-        name = item['name']
-        # Use regex to separate numeric and non-numeric parts
-        numeric_part = int(re.match(r'(\d+)', name).group(0)) if re.match(r'(\d+)', name) else float('inf')
-        non_numeric_part = re.sub(r'^\d+', '', name)  # Remove numeric part for sorting
-        return (numeric_part, non_numeric_part)
-
     def get_ws(self):
         ws_list = []
         workspaces = self.wm.get_workspaces()
         for ws in workspaces:
             ws_list.append({
+                "id": ws.id,
                 "name": ws.name,
                 "focused": ws.focused,
                 "output": ws.output,
                 "urgent": ws.urgent
             })
 
-        ws_list = sorted(ws_list, key=self.sort_key)
+        ws_list = sorted(ws_list, key=lambda d: int(d["id"]))
         self.workspaces = ws_list
 
     def update_boxes(self):
@@ -102,7 +96,8 @@ class Workspaces(Gtk.Box):
             for ws in self.workspaces:
                 if(self.monitor == "all" or ws["output"] == self.monitor):
                     show_name = self.ws_names[ws["name"]] if ws["name"] in self.ws_names else ""
-                    self.append(WorkspaceBox(name=ws["name"], show_name=show_name, focused=ws["focused"], urgent=ws["urgent"], icon_size=self.icon_size))
+                    if(ws["name"]):
+                        self.append(WorkspaceBox(id=ws["id"], name=ws["name"], show_name=show_name, focused=ws["focused"], urgent=ws["urgent"], icon_size=self.icon_size))
         
         return True
 


### PR DESCRIPTION
Fixed bug that ngb module for workspaces stops working if moving to a dynamic/unnamed workspace in niri.
Changed to use workspace id to sort workspaces since unnamed workspaces name is set to null.
Added id to workspaces tuple in HyprlandIPC to work with sorting change.
Reimplemented own version of SwayIPC that connect direct to UNIX socket to get it to work with workspace id.
Removed dependency i3ipc-python since SwayIPC replaced that function.