### PR TITLE
Fixed filtering of config if a default value of null is used

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -155,8 +155,14 @@ with lib;
         home.packages = [
             (optionalString (config.programs.ngb.package != null) config.programs.ngb.package)
         ];
-        xdg.configFile."ngb/config.json".text = ''
-            ${builtins.toJSON (lib.attrsets.filterAttrsRecursive (name: value: value != null) config.programs.ngb.settings)}
-        '';
+        xdg.configFile."ngb/config.json" = 
+            let
+                filterNulls = attrs: lib.filterAttrs (key: value: value != null) attrs;
+                filtered = filterNulls (config.programs.ngb.settings // { bars = map filterNulls config.programs.ngb.settings.bars; });
+            in{
+            text = ''
+                ${builtins.toJSON filtered}
+            '';
+        };
     };
 }


### PR DESCRIPTION
Fixed hm-module so if a default value is null when creating the configuration file in json, those values is filtered out and not stored inside the json file and by that make ngb use the default values stored in the code.
The options that have a default value of null is optional to set to be able to override the default values.