### PR TITLE
Fix/ipc socket

### DIFF
--- a/src/ngb/modules/__init__.py
+++ b/src/ngb/modules/__init__.py
@@ -1,7 +1,6 @@
 from .bar import Bar
 from .config import Config
 from .dropdownwindow import DropDownWindow
-from .hyprlandipc import HyprlandIpc
 from .namedtuples import NamedTuples
 from .niriipc import NiriIPC
 from .swayipc import SwayIPC

--- a/src/ngb/modules/niriipc.py
+++ b/src/ngb/modules/niriipc.py
@@ -18,32 +18,9 @@ class NiriIPC(WindowManagerIPC):
     active_workspaces = {}
 
     def __init__(self):
+        super().__init__()
         self.sock_req = f"{os.environ.get('NIRI_SOCKET')}"
-        self.usocket = None
         self.connect()
-
-    def connect(self):
-        self.usocket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        try:
-            self.usocket.connect(self.sock_req)
-        except ConnectionRefusedError:
-            print("Connection to the UNIX socket refused.")
-        except socket.error as e:
-            print(f"Error open socket: {e}")
-
-    def disconnect(self):
-        self.usocket.close()
-
-    def is_connected(self):
-        if self.usocket is None:
-            print("No socket created")
-            return False
-        try:
-            self.usocket.sendall(b"")
-            return True
-        except socket.error:
-            print("Niri IPC socket not connected")
-            return False
 
     def send_to_socket(self, cmd):
         if self.is_connected():

--- a/src/ngb/modules/niriipc.py
+++ b/src/ngb/modules/niriipc.py
@@ -19,17 +19,40 @@ class NiriIPC(WindowManagerIPC):
 
     def __init__(self):
         self.sock_req = f"{os.environ.get('NIRI_SOCKET')}"
+        self.usocket = None
+        self.connect()
+
+    def connect(self):
+        self.usocket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            self.usocket.connect(self.sock_req)
+        except ConnectionRefusedError:
+            print("Connection to the UNIX socket refused.")
+        except socket.error as e:
+            print(f"Error open socket: {e}")
+
+    def disconnect(self):
+        self.usocket.close()
+
+    def is_connected(self):
+        if self.usocket is None:
+            print("No socket created")
+            return False
+        try:
+            self.usocket.sendall(b"")
+            return True
+        except socket.error:
+            print("Niri IPC socket not connected")
+            return False
 
     def send_to_socket(self, cmd):
-        usocket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        try:
-            usocket.connect(self.sock_req)
+        if self.is_connected():
             try:
-                usocket.sendall(self.translate_cmd(cmd))
-                usocket.sendall("\n".encode("utf-8"))
+                self.usocket.sendall(self.translate_cmd(cmd))
+                self.usocket.sendall("\n".encode("utf-8"))
                 response = ""
                 while True:
-                    part = usocket.recv(1024)
+                    part = self.usocket.recv(1024)
                     response += part.decode("utf-8")
                     if len(part) < 1024:
                         break
@@ -40,12 +63,6 @@ class NiriIPC(WindowManagerIPC):
                 print("Error: Socket timed out")
             except Exception as e:
                 print(f"Error: {e}")
-        except ConnectionRefusedError:
-            print("Connection to the UNIX socket refused.")
-        except socket.error as e:
-            print(f"Error open socket: {e}")
-        finally:
-            usocket.close()
 
     def parse_workspace(self, ws):
         parsed_ws = list()

--- a/src/ngb/modules/swayipc.py
+++ b/src/ngb/modules/swayipc.py
@@ -15,36 +15,29 @@ Window = NamedTuples.Window
 class SwayIPC(WindowManagerIPC):
 
     def __init__(self):
+        super().__init__()
         self.sock_req = f"{os.environ.get('SWAYSOCK')}"
 
     def send_to_socket(self, cmd):
-        usocket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
-            usocket.connect(self.sock_req)
-            try:
-                usocket.sendall(self.translate_cmd(cmd))
-                usocket.sendall("\n".encode("utf-8"))
-                response = bytes()
-                while True:
-                    part = usocket.recv(1024)
-                    response += part
-                    if len(part) < 1024:
-                        break
-                response = response[14:].decode("utf-8")
-                match = re.search(r"^[\[\{][\W\w]*[\]\}]$", response).group(0)
-                if match:
-                    parsed_response = json.loads(match)
-                else:
-                    parsed_response = []
-                return parsed_response
-            except socket.error as e:
-                print(e)
-        except ConnectionRefusedError:
-            print("Connection to the UNIX socket refused.")
+            self.connect()
+            self.usocket.sendall(self.translate_cmd(cmd))
+            response = bytes()
+            while True:
+                part = self.usocket.recv(1024)
+                response += part
+                if len(part) < 1024:
+                    break
+            response = response[14:].decode("utf-8")
+            match = re.search(r"^[\[\{][\W\w]*[\]\}]$", response).group(0)
+            if match:
+                parsed_response = json.loads(match)
+            else:
+                parsed_response = []
+            self.disconnect()
+            return parsed_response
         except socket.error as e:
-            print(f"Error open socket: {e}")
-        finally:
-            usocket.close()
+            print(e)
 
     def get_workspaces(self):
         wss = self.send_to_socket("GET_WORKSPACES")
@@ -121,5 +114,7 @@ class SwayIPC(WindowManagerIPC):
         cmd_len = struct.pack("@i", len(cmd))
         cmd_type = struct.pack("@i", cmd_id)
 
-        cmd_str = magic_string + cmd_len + cmd_type + cmd.encode("utf8")
+        cmd_str = (
+            magic_string + cmd_len + cmd_type + cmd.encode("utf8") + "\n".encode("utf8")
+        )
         return cmd_str

--- a/src/ngb/modules/windowmanageripc.py
+++ b/src/ngb/modules/windowmanageripc.py
@@ -1,15 +1,32 @@
+import socket
+
+
 class WindowManagerIPC:
     def __init__(self):
-        pass
+        self.usocket = None
 
     def connect(self):
-        pass
+        self.usocket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            self.usocket.connect(self.sock_req)
+        except ConnectionRefusedError:
+            print("Connection to the UNIX socket refused.")
+        except socket.error as e:
+            print(f"Error open socket: {e}")
 
     def disconnect(self):
-        pass
+        self.usocket.close()
 
     def is_connected(self):
-        return False
+        if self.usocket is None:
+            print("No socket created")
+            return False
+        try:
+            self.usocket.sendall(b"")
+            return True
+        except socket.error:
+            print("IPC socket not connected")
+            return False
 
     def send_to_socket(self, cmd):
         pass

--- a/src/ngb/modules/windowmanageripc.py
+++ b/src/ngb/modules/windowmanageripc.py
@@ -2,6 +2,15 @@ class WindowManagerIPC:
     def __init__(self):
         pass
 
+    def connect(self):
+        pass
+
+    def disconnect(self):
+        pass
+
+    def is_connected(self):
+        return False
+
     def send_to_socket(self, cmd):
         pass
 

--- a/src/ngb/widgets/windowtitle.py
+++ b/src/ngb/widgets/windowtitle.py
@@ -6,7 +6,7 @@ import os
 from collections import namedtuple
 import socket
 
-from ngb.modules import HyprlandIpc, NiriIPC, SwayIPC, WidgetBox, WindowManagerIPC
+from ngb.modules import NiriIPC, SwayIPC, WidgetBox, WindowManagerIPC
 
 
 class WindowButton(Gtk.Box):
@@ -41,8 +41,6 @@ class WindowButton(Gtk.Box):
 class WindowTitle(WidgetBox):
     if os.environ["XDG_CURRENT_DESKTOP"] == "sway":
         wm = SwayIPC()
-    elif os.environ["XDG_CURRENT_DESKTOP"] == "Hyprland":
-        wm = HyprlandIpc()
     elif os.environ["XDG_CURRENT_DESKTOP"] == "niri":
         wm = NiriIPC()
     # If using a non-supported window manager and show empty space instead of giving error
@@ -103,7 +101,7 @@ class WindowTitle(WidgetBox):
             return " ".join(new_title[:-1])
 
     def on_click(self, user_data):
-        if not isinstance(self.wm, HyprlandIpc):
+        if isinstance(self.wm, NiriIPC) or isinstance(self.wm, SwayIPC):
             self.populate_dropdown()
             self.dropdown.popup()
         return True

--- a/src/ngb/widgets/workspaces.py
+++ b/src/ngb/widgets/workspaces.py
@@ -18,13 +18,6 @@ Workspace = NamedTuples.Workspace
 
 
 class WorkspaceBox(WidgetBox):
-    if os.environ["XDG_CURRENT_DESKTOP"] == "sway":
-        wm = SwayIPC()
-    elif os.environ["XDG_CURRENT_DESKTOP"] == "niri":
-        wm = NiriIPC()
-    # If using a non-supported window manager and show empty space instead of giving error
-    else:
-        wm = WindowManagerIPC()
 
     def __init__(self, **kwargs):
         self.name = kwargs.get("name", "")
@@ -32,6 +25,7 @@ class WorkspaceBox(WidgetBox):
         self.focused = kwargs.get("focused", False)
         self.urgent = kwargs.get("urgent", False)
         self.icon_size = kwargs.get("icon_size", 20)
+        self.wm = kwargs.get("wm", WindowManagerIPC())
         super().__init__(icon=self.show_name, text=self.name, icon_size=self.icon_size)
         self.hide_label()
         self.set_focused()
@@ -126,6 +120,7 @@ class Workspaces(Gtk.Box):
                             focused=ws.focused,
                             urgent=ws.urgent,
                             icon_size=self.icon_size,
+                            wm=self.wm,
                         )
                     )
 

--- a/src/ngb/widgets/workspaces.py
+++ b/src/ngb/widgets/workspaces.py
@@ -7,7 +7,6 @@ from collections import namedtuple
 import socket
 
 from ngb.modules import (
-    HyprlandIpc,
     NamedTuples,
     NiriIPC,
     SwayIPC,
@@ -21,8 +20,6 @@ Workspace = NamedTuples.Workspace
 class WorkspaceBox(WidgetBox):
     if os.environ["XDG_CURRENT_DESKTOP"] == "sway":
         wm = SwayIPC()
-    elif os.environ["XDG_CURRENT_DESKTOP"] == "Hyprland":
-        wm = HyprlandIpc()
     elif os.environ["XDG_CURRENT_DESKTOP"] == "niri":
         wm = NiriIPC()
     # If using a non-supported window manager and show empty space instead of giving error
@@ -63,8 +60,6 @@ class Workspaces(Gtk.Box):
     old_workspaces = []
     if os.environ["XDG_CURRENT_DESKTOP"] == "sway":
         wm = SwayIPC()
-    elif os.environ["XDG_CURRENT_DESKTOP"] == "Hyprland":
-        wm = HyprlandIpc()
     elif os.environ["XDG_CURRENT_DESKTOP"] == "niri":
         wm = NiriIPC()
     # If using a non-supported window manager and show empty space instead of giving error


### PR DESCRIPTION
Changed to use open connection to the unix socket instead of open and close connection (not fully open for sway IPC)
Changed to send the IPC instance from workspaces instance into every workspacebox instance created instead of creating a new IPC instance for every new workspacebox created since that needs to make a new connection to the unix socket up to multiple times a second, which now only need to be done when the workspace instance is created
Removed support for Hyprland since I dont use it anymore (and dont want to keep updating code that will never be used anyway), but save the code if anything change in the future and only remove the imports of it in the code (only workspace and windowtitle widgets is affected by the change)