### PR TITLE
Feature/recreate crashed widgets

### DIFF
--- a/src/ngb/modules/bar.py
+++ b/src/ngb/modules/bar.py
@@ -91,3 +91,39 @@ class Bar(Gtk.ApplicationWindow):
     def right(self, widget):
         self.rightbox.append(widget)
         return True
+
+    def left_insert(self, widget, sibling):
+        self.leftbox.insert_child_after(widget, sibling)
+        return True
+
+    def center_insert(self, widget, sibling):
+        self.centerbox.insert_child_after(widget, sibling)
+        return True
+
+    def right_insert(self, widget, sibling):
+        self.rightbox.insert_child_after(widget, sibling)
+        return True
+
+    def get_left_child(self):
+        left_childs = []
+        child = self.leftbox.get_first_child()
+        while child:
+            left_childs.append(child)
+            child = child.get_next_sibling()
+        return left_childs
+
+    def get_center_child(self):
+        center_childs = []
+        child = self.centerbox.get_first_child()
+        while child:
+            center_childs.append(child)
+            child = child.get_next_sibling()
+        return center_childs
+
+    def get_right_child(self):
+        right_childs = []
+        child = self.rightbox.get_first_child()
+        while child:
+            right_childs.append(child)
+            child = child.get_next_sibling()
+        return right_childs

--- a/src/ngb/modules/widgetbox.py
+++ b/src/ngb/modules/widgetbox.py
@@ -63,10 +63,27 @@ class WidgetBox(Gtk.Button):
         self.box.append(self.icon_label)
         self.box.append(self.text_label)
 
+        # Store the running timer to be able to stop it
+        self.timeout = None
+
+        # Check if widget is stopped
+        self.is_stopped = False
+
     def run(self):
         self.set_icon()
         self.set_text()
         self.update_label()
+
+    def stop(self):
+        self.is_stopped = True
+        if self.timeout:
+            GLib.source_remove(self.timeout)
+            self.timeout = None
+
+    def remove_widget(self):
+        parent = self.get_parent()
+        if parent:
+            parent.remove(self)
 
     def on_scroll(self, controller, x, y):
         pass
@@ -99,5 +116,5 @@ class WidgetBox(Gtk.Button):
         return True
 
     def update_label(self):
-        GLib.timeout_add(self.timer * 1000, self.set_text)
+        self.timeout = GLib.timeout_add(self.timer * 1000, self.set_text)
         return True

--- a/src/ngb/ngb.py
+++ b/src/ngb/ngb.py
@@ -103,6 +103,7 @@ class MainWindow(Gtk.Application):
             local_bar_config["layer"] = self.config.data.get("layer", "bottom")
         window = Bar(app=self, **local_bar_config)
         window.show()
+        self.bars.append(window)
 
         valid_widgets = {
             "battery": Battery,

--- a/src/ngb/ngb.py
+++ b/src/ngb/ngb.py
@@ -16,6 +16,7 @@ from gi.repository import GLib
 
 import sys
 import uuid
+import time
 
 from ngb.widgets import (
     Battery,
@@ -69,7 +70,10 @@ class MainWindow(Gtk.Application):
             None,
         )
 
+        self.bars = []
+
     def do_activate(self):
+        self.start_recreate_timer()
         if self.config_file_path:
             self.config = Config(
                 file_path=self.config_file_path, file_type=self.config_file_type
@@ -196,6 +200,55 @@ class MainWindow(Gtk.Application):
                 self.config_file_type = options.get("type")
             self.activate()
         return True
+
+    def recreate_stopped_widgets(self):
+        for bar in self.bars:
+            left = bar.get_left_child()
+            center = bar.get_center_child()
+            right = bar.get_right_child()
+
+            for widget in left:
+                if widget.is_stopped:
+                    widget_type = type(widget)
+                    widget_config = widget.__dict__
+                    sibling = widget.get_prev_sibling()
+                    widget.remove_widget()
+                    new_module = (widget_type)(**widget_config)
+                    if sibling:
+                        bar.left_insert(new_module, sibling)
+                    else:
+                        bar.leftbox.prepend((widget_type)(**config))
+                    new_module.run()
+
+            for widget in center:
+                if widget.is_stopped:
+                    widget_type = type(widget)
+                    widget_config = widget.__dict__
+                    sibling = widget.get_prev_sibling()
+                    widget.remove_widget()
+                    new_module = (widget_type)(**widget_config)
+                    if sibling:
+                        bar.center_insert(new_module, sibling)
+                    else:
+                        bar.centerbox.prepend((widget_type)(**config))
+                    new_module.run()
+
+            for widget in right:
+                if widget.is_stopped:
+                    widget_type = type(widget)
+                    widget_config = widget.__dict__
+                    sibling = widget.get_prev_sibling()
+                    widget.remove_widget()
+                    new_module = (widget_type)(**widget_config)
+                    if sibling:
+                        bar.right_insert(new_module, sibling)
+                    else:
+                        bar.rightbox.prepend((widget_type)(**config))
+                    new_module.run()
+        return True
+
+    def start_recreate_timer(self):
+        GLib.timeout_add(5 * 1000, self.recreate_stopped_widgets)
 
 
 def main():

--- a/src/ngb/widgets/bluetooth.py
+++ b/src/ngb/widgets/bluetooth.py
@@ -19,10 +19,23 @@ class Bluetooth(Gtk.Box):
         self.spacing = kwargs.get("spacing", 10)
         self.icon_size = kwargs.get("icon_size", 20)
         super().__init__(spacing=self.spacing)
+        self.is_stopped = False
+        self.timeout = None
 
     def run(self):
         self.update_boxes()
         self.update_list()
+
+    def stop(self):
+        self.is_stopped = True
+        if self.timeout:
+            GLib.source_remove(self.timeout)
+            self.timeout = None
+
+    def remove_widget(self):
+        parent = self.get_parent()
+        if parent:
+            parent.remove(self)
 
     def update_boxes(self):
         while self.get_first_accessible_child() is not None:
@@ -77,5 +90,5 @@ class Bluetooth(Gtk.Box):
         )
 
     def update_list(self):
-        GLib.timeout_add(self.timer * 1000, self.update_boxes)
+        self.timeout = GLib.timeout_add(self.timer * 1000, self.update_boxes)
         return True

--- a/src/ngb/widgets/headset.py
+++ b/src/ngb/widgets/headset.py
@@ -45,6 +45,7 @@ class Headset(WidgetBox):
                 print(e)
                 self.text_label.set_text("Headsetcontrol timedout")
                 self.stop()
+                return False
         else:
             self.text_label.set_text("headsetcontrol not installed")
         return True

--- a/src/ngb/widgets/headset.py
+++ b/src/ngb/widgets/headset.py
@@ -44,6 +44,7 @@ class Headset(WidgetBox):
             except subprocess.TimeoutExpired as e:
                 print(e)
                 self.text_label.set_text("Headsetcontrol timedout")
+                self.stop()
         else:
             self.text_label.set_text("headsetcontrol not installed")
         return True

--- a/src/ngb/widgets/workspaces.py
+++ b/src/ngb/widgets/workspaces.py
@@ -69,6 +69,8 @@ class Workspaces(Gtk.Box):
         self.use_workspace_names = kwargs.get("use_workspace_names", False)
         self.ws_names = kwargs.get("names", {})
         self.default_name = kwargs.get("default_name", "*")
+        self.is_stopped = False
+        self.timeout = None
         self.update_boxes()
         self.update_list()
         self.scroll_controller = Gtk.EventControllerScroll.new(
@@ -79,6 +81,17 @@ class Workspaces(Gtk.Box):
 
     def run(self):
         pass
+
+    def stop(self):
+        self.is_stopped = True
+        if self.timeout:
+            GLib.source_remove(self.timeout)
+            self.timeout = None
+
+    def remove_widget(self):
+        parent = self.get_parent()
+        if parent:
+            parent.remove(self)
 
     def get_ws(self):
         ws_list = []
@@ -127,7 +140,7 @@ class Workspaces(Gtk.Box):
         return True
 
     def update_list(self):
-        GLib.timeout_add(self.timer * 1000, self.update_boxes)
+        self.timeout = GLib.timeout_add(self.timer * 1000, self.update_boxes)
 
     def on_scroll(self, controller, x, y):
         if y < 0:


### PR DESCRIPTION
Created methods to recreate a instance of a widget that has crashed (mostly headset which hangs on crash of headsets wireless controller when trying to access it to often)