### PR TITLE
Fix/socket data

### DIFF
--- a/src/ngb/modules/niriipc.py
+++ b/src/ngb/modules/niriipc.py
@@ -5,6 +5,7 @@ import os
 import json
 from operator import itemgetter
 import traceback
+import random
 
 from .namedtuples import NamedTuples
 from .windowmanageripc import WindowManagerIPC
@@ -57,6 +58,7 @@ class NiriIPC(WindowManagerIPC):
             if (
                 wss != {}
                 and wss["active_window_id"] != None
+                and self.active_workspaces.get(wss.get("output", "")) != None
                 or (wss["is_active"] and wss["active_window_id"] == None)
             ):
                 ws_dict["id"] = wss.get("idx", 0)

--- a/src/ngb/modules/niriipc.py
+++ b/src/ngb/modules/niriipc.py
@@ -4,6 +4,7 @@ import re
 import os
 import json
 from operator import itemgetter
+import traceback
 
 from .namedtuples import NamedTuples
 from .windowmanageripc import WindowManagerIPC
@@ -23,23 +24,28 @@ class NiriIPC(WindowManagerIPC):
         self.connect()
 
     def send_to_socket(self, cmd):
+        socket_data = {}
         if self.is_connected():
             try:
                 self.usocket.sendall(self.translate_cmd(cmd))
                 self.usocket.sendall("\n".encode("utf-8"))
-                response = ""
+                response = bytearray()
                 while True:
                     part = self.usocket.recv(1024)
-                    response += part.decode("utf-8")
+                    response.extend(part)
                     if len(part) < 1024:
                         break
-                return json.loads(response)
+                response = response.decode("utf-8")
+                socket_data = json.loads(response)
             except socket.error as e:
                 print(e)
             except socket.timeout:
                 print("Error: Socket timed out")
-            except Exception as e:
-                print(f"Error: {e}")
+            except Exception:
+                traceback.print_exc()
+                print("-" * 15)
+            finally:
+                return socket_data
 
     def parse_workspace(self, ws):
         parsed_ws = list()

--- a/src/ngb/modules/niriipc.py
+++ b/src/ngb/modules/niriipc.py
@@ -24,7 +24,7 @@ class NiriIPC(WindowManagerIPC):
         self.connect()
 
     def send_to_socket(self, cmd):
-        socket_data = {}
+        socket_data = []
         if self.is_connected():
             try:
                 self.usocket.sendall(self.translate_cmd(cmd))
@@ -36,7 +36,9 @@ class NiriIPC(WindowManagerIPC):
                     if len(part) < 1024:
                         break
                 response = response.decode("utf-8")
-                socket_data = json.loads(response)
+                response = json.loads(response)
+                response = response.get("Ok", {}).get(cmd, [])
+                socket_data = response
             except socket.error as e:
                 print(e)
             except socket.timeout:
@@ -79,10 +81,8 @@ class NiriIPC(WindowManagerIPC):
 
     def get_workspaces(self):
         workspaces = self.send_to_socket("Workspaces")
-        if workspaces and "Ok" in workspaces:
-            parsed_ws = self.parse_workspace(
-                workspaces.get("Ok", {}).get("Workspaces", [])
-            )
+        if workspaces:
+            parsed_ws = self.parse_workspace(workspaces)
             ws_list = list()
             for p in parsed_ws:
                 ws_list.append(
@@ -99,17 +99,16 @@ class NiriIPC(WindowManagerIPC):
 
     def get_outputs(self):
         outputs = self.send_to_socket("Outputs")
-        if outputs and "Ok" in outputs:
-            parsed_outputs = list(outputs.get("Ok", {}).get("Outputs", {}).keys())
+        if outputs:
+            parsed_outputs = list(outputs.keys())
             for out in parsed_outputs:
                 self.active_workspaces[out] = []
 
     def get_windows(self):
         windows = self.send_to_socket("Windows")
         windows_list = []
-        if windows and "Ok" in windows:
-            parsed_windows = windows.get("Ok", {}).get("Windows", [])
-            for w in parsed_windows:
+        if windows:
+            for w in windows:
                 windows_list.append(
                     Window(
                         id=w.get("id"),

--- a/src/ngb/modules/swayipc.py
+++ b/src/ngb/modules/swayipc.py
@@ -4,6 +4,7 @@ import re
 import os
 import struct
 import json
+import traceback
 
 from .namedtuples import NamedTuples
 from .windowmanageripc import WindowManagerIPC
@@ -19,6 +20,7 @@ class SwayIPC(WindowManagerIPC):
         self.sock_req = f"{os.environ.get('SWAYSOCK')}"
 
     def send_to_socket(self, cmd):
+        socket_data = []
         try:
             self.connect()
             self.usocket.sendall(self.translate_cmd(cmd))
@@ -35,9 +37,13 @@ class SwayIPC(WindowManagerIPC):
             else:
                 parsed_response = []
             self.disconnect()
-            return parsed_response
+            socket_data = parsed_response
         except socket.error as e:
             print(e)
+        except Exception:
+            traceback.print_exc()
+        finally:
+            return socket_data
 
     def get_workspaces(self):
         wss = self.send_to_socket("GET_WORKSPACES")

--- a/src/ngb/modules/windowmanageripc.py
+++ b/src/ngb/modules/windowmanageripc.py
@@ -29,7 +29,7 @@ class WindowManagerIPC:
             return False
 
     def send_to_socket(self, cmd):
-        return {}
+        return []
 
     def parse_workspace(self, ws):
         return []

--- a/src/ngb/modules/windowmanageripc.py
+++ b/src/ngb/modules/windowmanageripc.py
@@ -29,7 +29,7 @@ class WindowManagerIPC:
             return False
 
     def send_to_socket(self, cmd):
-        pass
+        return {}
 
     def parse_workspace(self, ws):
         return []
@@ -57,4 +57,4 @@ class WindowManagerIPC:
         return ""
 
     def command(self, cmd):
-        self.send_to_socket(cmd)
+        return self.send_to_socket(cmd)


### PR DESCRIPTION
Changed order in which the niriipc append each part of the data received from the socket and decoding the data from socket
Added a finally to always return data from send_to_socket() even if an exception is thrown, which now will return an empty list if there is any errors, for both niriipc and swayipc.
Changed windowmanageripc to always return empty list for send_to_socket() to always have a datatype to work with if using non-supported window manager, if needed