### PR TITLE
Fix/set min timer headset

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ Show the percentage used of the chosen mountpoint, and if clicked on will show a
 ##### Headset
 Use the command headsetcontrol to show current battery level of compatible headset.
 headsetcontrol is needed to be in $PATH to work.
+Have a minimum timer set at 5 seconds
+(May remove this in the future since it is unstable and can crash the headset controller if to many requests is sent to the headset at a low interval)
 
 ##### Network
 Show ipv4 address of chosen interface. When clicked on show a dropdown with interface name, mac address, ipv4 address and ipv6 addresses of interface.

--- a/src/ngb/widgets/headset.py
+++ b/src/ngb/widgets/headset.py
@@ -10,9 +10,13 @@ from ngb.modules import WidgetBox
 
 
 class Headset(WidgetBox):
+    min_timer = 5
+
     def __init__(self, **kwargs):
         self.icon = kwargs.get("icon", "󰋎")
-        self.timer = kwargs.get("timer", 1)
+        self.timer = kwargs.get("timer", self.min_timer)
+        if self.timer < self.min_timer:
+            self.timer = self.min_timer
         self.icon_size = kwargs.get("icon_size", 20)
         super().__init__(icon=self.icon, icon_size=self.icon_size, timer=self.timer)
 


### PR DESCRIPTION
Added a min timer to limit the amount of request done to the headset controller to hopefully not crash it
Added note in the README that this widget may be removed in the future since it is not a stable enough solution, if not better fix is found