### PR TITLE
Changed to use exception instead of isinstance()

### DIFF
--- a/src/ngb/modules/niriipc.py
+++ b/src/ngb/modules/niriipc.py
@@ -38,13 +38,14 @@ class NiriIPC(WindowManagerIPC):
                         break
                 response = response.decode("utf-8")
                 response = json.loads(response)
-                if isinstance(response, dict):
-                    response = response.get("Ok", {}).get(cmd, [])
-                    socket_data = response
+                response = response.get("Ok", {}).get(cmd, [])
+                socket_data = response
             except socket.error as e:
                 print(e)
             except socket.timeout:
                 print("Error: Socket timed out")
+            except AttributeError as e:
+                print(e)
             except Exception:
                 traceback.print_exc()
                 print("-" * 15)


### PR DESCRIPTION
Changed to use an exception instead of check if instance is a dictionary before returning the socket data