### PR TITLE
Moved error check for bluetooth into module

### DIFF
--- a/src/ngb/modules/bluetooth.py
+++ b/src/ngb/modules/bluetooth.py
@@ -1,4 +1,5 @@
 from pydbus import SystemBus
+from gi.repository import GLib
 
 import re
 
@@ -16,10 +17,16 @@ class BluetoothModule:
         pass
 
     def get_controllers(self):
-        proxy = self.system_bus.get(self.dbus_interface)
-        proxy_data = proxy.Introspect()
-        controllers = re.findall(r"<node name=\"([\w]+)\"/>", proxy_data)
-        return controllers
+        try:
+            proxy = self.system_bus.get(self.dbus_interface)
+            proxy_data = proxy.Introspect()
+            controllers = re.findall(r"<node name=\"([\w]+)\"/>", proxy_data)
+            if controllers:
+                return controllers
+            else:
+                return []
+        except GLib.GError as e:
+            return []
 
     def get_devices(self, controller):
         proxy = self.system_bus.get(self.dbus_interface, controller)

--- a/src/ngb/widgets/bluetooth.py
+++ b/src/ngb/widgets/bluetooth.py
@@ -33,10 +33,7 @@ class Bluetooth(Gtk.Box):
     def update_boxes(self):
         while self.get_first_accessible_child() is not None:
             self.remove(self.get_first_accessible_child())
-        try:
-            device_list = self.devices.get_device_list()
-        except GLib.GError:
-            device_list = []
+        device_list = self.devices.get_device_list()
         for device in device_list:
             bluetooth_box = WidgetBox(
                 icon=device.icon,


### PR DESCRIPTION
Moved the error check into the module to where it try to access the dbus interface since it is where the exception is thrown if bluez is not installed