### PR TITLE
Changed to static icon since bluez not reporting device type

### DIFF
--- a/src/ngb/modules/bluetooth.py
+++ b/src/ngb/modules/bluetooth.py
@@ -49,7 +49,7 @@ class BluetoothModule:
             address=device.Address if "Address" in dir(device) else "",
             battery=f"{device.Percentage}%" if "Percentage" in dir(device) else "0",
             connected=device.Connected if "Connected" in dir(device) else False,
-            icon=self.icons.get(device.Icon, "󰥈"),
+            icon="󰥉",
             name=device.Name if "Name" in dir(device) else "",
         )
 


### PR DESCRIPTION
Changed to use a single icon for all device types since bluez not reporting device type in the same way as earlier after an update